### PR TITLE
Fix installation on puppet managed servers.

### DIFF
--- a/puppet/zulip/manifests/profile/base.pp
+++ b/puppet/zulip/manifests/profile/base.pp
@@ -3,7 +3,8 @@
 # This class should only be included by classes that are intended to
 # be able to be deployed on their own host.
 class zulip::profile::base {
-  include zulip::timesync
+  # it is default on Ubuntu, and default chrony on redhat
+  # include zulip::timesync
   include zulip::common
   case $facts['os']['family'] {
     'Debian': {
@@ -22,7 +23,6 @@ class zulip::profile::base {
         # Basics
         'python3',
         'python3-yaml',
-        'puppet',
         'git',
         'curl',
         'jq',
@@ -43,7 +43,6 @@ class zulip::profile::base {
       $base_packages = [
         'python3',
         'python3-pyyaml',
-        'puppet',
         'git',
         'curl',
         'jq',
@@ -114,12 +113,6 @@ class zulip::profile::base {
     owner  => 'root',
     group  => 'root',
     source => 'puppet:///modules/zulip/systemd/system.conf.d/limits.conf',
-  }
-
-  service { 'puppet':
-    ensure  => stopped,
-    enable  => false,
-    require => Package['puppet'],
   }
 
   # This directory is written to by cron jobs for reading by Nagios

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -217,7 +217,7 @@ export LANGUAGE="C.UTF-8"
 
 # Force a known path; this fixes problems on Debian where `su` from
 # non-root may not adjust `$PATH` to root's.
-export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/puppetlabs/bin"
 
 # Check for a supported OS release.
 if [ -f /etc/os-release ]; then
@@ -411,6 +411,7 @@ fi
 
 # Generate /etc/zulip/zulip.conf .
 mkdir -p /etc/zulip
+mkdir -p /var/lib/puppet
 has_class() {
     grep -qx "$1" /var/lib/puppet/classes.txt
 }

--- a/scripts/lib/puppet_cache.py
+++ b/scripts/lib/puppet_cache.py
@@ -23,8 +23,7 @@ def generate_sha1sum_puppet_modules() -> str:
     with open(PUPPET_DEPS_FILE_PATH) as fb:
         data["deps.yaml"] = fb.read().strip()
     data["puppet-version"] = subprocess.check_output(
-        # This is 10x faster than `puppet --version`
-        ["ruby", "-r", "puppet/version", "-e", "puts Puppet.version"],
+        ["puppet", "--version"],
         text=True,
     ).strip()
 

--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -41,7 +41,7 @@ from scripts.lib.zulip_tools import (
 assert_running_as_root()
 
 # Set a known, reliable PATH
-os.environ["PATH"] = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+os.environ["PATH"] = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/puppetlabs/bin"
 
 logging.Formatter.converter = time.gmtime
 logging.basicConfig(format="%(asctime)s upgrade-zulip-stage-2: %(message)s", level=logging.INFO)


### PR DESCRIPTION
Removes installation of puppet packages as puppet is already installed from puppetlabs repo. Fixes the path to include puppet binary. Adds folder for puppet classfile, as puppetlabs has all in /opt/puppetlabs.